### PR TITLE
fix: shade level7 not equals to brandColor bug

### DIFF
--- a/packages/dls-color-palette/CHANGELOG.md
+++ b/packages/dls-color-palette/CHANGELOG.md
@@ -1,8 +1,15 @@
 > ⚠️ - Breaking Changes
 
+
+## 0.0.1-alpha.2
+
+- fix: shade level7 not equals to brandColor bug.
+
 ## 0.0.1-alpha.1
+
 - build: change babelHelpers from `runtime` to `bundled`.
 - chore: delete useless dependencies.
 
 ## 0.0.1-alpha.0
+
 - First release.

--- a/packages/dls-color-palette/package-lock.json
+++ b/packages/dls-color-palette/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dls-color-palette",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/dls-color-palette/package.json
+++ b/packages/dls-color-palette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dls-color-palette",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "color palette generator for BAIDU DLS.",
   "main": "dist/index.cjs.mim.js",
   "module": "dist/index.esm.min.js",

--- a/packages/dls-color-palette/src/shade.js
+++ b/packages/dls-color-palette/src/shade.js
@@ -74,7 +74,7 @@ export default function getShade (color, level) {
   const b = rawB * 100
 
   if (level === BASE_LEVEL) {
-    return hsvToHex([h, s, b])
+    return color
   }
 
   let brightness = getBrightness(b, level)

--- a/packages/dls-color-palette/src/shade.js
+++ b/packages/dls-color-palette/src/shade.js
@@ -69,13 +69,14 @@ export default function getShade (color, level) {
   if (!isNumber(level) || level < 1 || level > 10) {
     throw new Error('`level` should be a number that ≥ 1 and ≤ 10.')
   }
-  const [h, rawS, rawB] = hexToHsv(color)
-  const s = rawS * 100
-  const b = rawB * 100
 
   if (level === BASE_LEVEL) {
     return color
   }
+
+  const [h, rawS, rawB] = hexToHsv(color)
+  const s = rawS * 100
+  const b = rawB * 100
 
   let brightness = getBrightness(b, level)
   let deviation =

--- a/packages/dls-color-palette/test/shade.spec.js
+++ b/packages/dls-color-palette/test/shade.spec.js
@@ -17,3 +17,8 @@ test('getShades', () => {
   expect(getShade(brandColor, 9)).toBe('#003585')
   expect(getShade(brandColor, 10)).toBe('#002152')
 })
+
+test('getShade: level=7 equals to brandColor', () => {
+  const brandColor = '#BD8552'
+  expect(getShade(brandColor, 7)).toBe(brandColor)
+})


### PR DESCRIPTION
before: getShade('#BD8552',  7) !== '#BD8552'
after: getShade('#BD8552',  7) === '#BD8552'